### PR TITLE
Facilitate code-splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,31 @@ import PWAPrompt from 'react-ios-pwa-prompt'
 ```
 <PWAPrompt promptOnVisit={1} timesToShow={3} copyClosePrompt="Close" permanentlyHideOnDismiss={false}/>
 ```
+
+## Code-splitting
+
+You may want to use [code-splitting](https://reactjs.org/docs/code-splitting.html) to avoid unnecessarily loading the component (including styles and icons) when it isn't going to be shown.
+Use the exported `shouldShowPrompt` function to determine whether to import the component, for example:
+
+```jsx
+import shouldShowPrompt from "react-ios-pwa-prompt/src/shouldShowPrompt";
+
+const LazyPWAPrompt = React.lazy(() => import("react-ios-pwa-prompt"));
+
+function render() {
+  const options = {
+    timesToShow: 1,
+    promptOnVisit: 2,
+  };
+
+  if (shouldShowPrompt(options)) {
+    return (
+      <Suspense fallback={null}>
+        <LazyPWAPrompt {...options} />
+      </Suspense>
+    );
+  }
+  
+  return null;
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,7 @@
 import React from "react";
 
+import shouldShowPrompt from "./shouldShowPrompt";
 import PWAPrompt from "./components/PWAPrompt";
-
-const deviceCheck = () => {
-  const isiOS = /iphone|ipad|ipod/.test(
-    window.navigator.userAgent.toLowerCase()
-  );
-  const isiPadOS =
-    navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
-  const isStandalone =
-    "standalone" in window.navigator && window.navigator.standalone;
-
-  return (isiOS || isiPadOS) && !isStandalone;
-};
 
 export default ({
   timesToShow = 1,
@@ -27,43 +16,23 @@ export default ({
   debug = false,
   onClose = () => {},
 }) => {
-  let promptData = JSON.parse(localStorage.getItem("iosPwaPrompt"));
+  if (shouldShowPrompt({ timesToShow, promptOnVisit, debug })) {
+    const promptData = JSON.parse(localStorage.getItem("iosPwaPrompt"));
 
-  if (promptData === null) {
-    promptData = { isiOS: deviceCheck(), visits: 0 };
-    localStorage.setItem("iosPwaPrompt", JSON.stringify(promptData));
-  }
-
-  if (promptData.isiOS || debug) {
-    const aboveMinVisits = promptData.visits + 1 >= promptOnVisit;
-    const belowMaxVisits = promptData.visits + 1 < promptOnVisit + timesToShow;
-
-    if (belowMaxVisits || debug) {
-      localStorage.setItem(
-        "iosPwaPrompt",
-        JSON.stringify({
-          ...promptData,
-          visits: promptData.visits + 1,
-        })
-      );
-
-      if (aboveMinVisits || debug) {
-        return (
-          <PWAPrompt
-            delay={delay}
-            copyTitle={copyTitle}
-            copyBody={copyBody}
-            copyAddHomeButtonLabel={copyAddHomeButtonLabel}
-            copyShareButtonLabel={copyShareButtonLabel}
-            copyClosePrompt={copyClosePrompt}
-            permanentlyHideOnDismiss={permanentlyHideOnDismiss}
-            promptData={promptData}
-            maxVisits={timesToShow + promptOnVisit}
-            onClose={onClose}
-          />
-        );
-      }
-    }
+    return (
+      <PWAPrompt
+        delay={delay}
+        copyTitle={copyTitle}
+        copyBody={copyBody}
+        copyAddHomeButtonLabel={copyAddHomeButtonLabel}
+        copyShareButtonLabel={copyShareButtonLabel}
+        copyClosePrompt={copyClosePrompt}
+        permanentlyHideOnDismiss={permanentlyHideOnDismiss}
+        promptData={promptData}
+        maxVisits={timesToShow + promptOnVisit}
+        onClose={onClose}
+      />
+    )
   }
 
   return null;

--- a/src/shouldShowPrompt.js
+++ b/src/shouldShowPrompt.js
@@ -1,0 +1,45 @@
+function deviceCheck() {
+  const isiOS = /iphone|ipad|ipod/.test(
+    window.navigator.userAgent.toLowerCase()
+  );
+  const isiPadOS =
+    navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+  const isStandalone =
+    "standalone" in window.navigator && window.navigator.standalone;
+
+  return (isiOS || isiPadOS) && !isStandalone;
+}
+
+export default function shouldShowPrompt({
+  timesToShow = 1,
+  promptOnVisit = 1,
+  debug = false,
+}) {
+  let promptData = JSON.parse(localStorage.getItem("iosPwaPrompt"));
+
+  if (promptData === null) {
+    promptData = { isiOS: deviceCheck(), visits: 0 };
+    localStorage.setItem("iosPwaPrompt", JSON.stringify(promptData));
+  }
+
+  if (promptData.isiOS || debug) {
+    const aboveMinVisits = promptData.visits + 1 >= promptOnVisit;
+    const belowMaxVisits = promptData.visits + 1 < promptOnVisit + timesToShow;
+
+    if (belowMaxVisits || debug) {
+      localStorage.setItem(
+        "iosPwaPrompt",
+        JSON.stringify({
+          ...promptData,
+          visits: promptData.visits + 1,
+        })
+      );
+
+      if (aboveMinVisits || debug) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
See #67

I thought this PR would be easy, but there are some issues:

1. Since the current build setup makes it difficult to compile code that is suitable for tree-shaking/code-splitting, I decided to suggest importing the `shouldShowPrompt` function directly from the `src/` directory instead. Not ideal, but it might be OK.
2. The `shouldShowPrompt` function will be called twice: once by the developer to determine whether to import the rest of the library, and once by the library to determine whether to show the prompt. This would be fine, except the function has side-effects: it increments the `visits` counter on each call, meaning that the prompt might be shown too soon or not at all. This is breaking.

What are your thoughts on this, @chrisdancee? 